### PR TITLE
Include "Precision alignment" flag

### DIFF
--- a/snippets/precision-alignment.sublime-snippet
+++ b/snippets/precision-alignment.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+	<content><![CDATA[
+// WPCS: precision alignment ok.
+]]></content>
+	<tabTrigger>wpcs</tabTrigger>
+	<scope>source.php</scope>
+	<description>WPCS: precision alignment ok</description>
+</snippet>


### PR DESCRIPTION
Introduced in WPCS 0.14.0+
https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Whitelisting-code-which-flags-errors#precision-alignment